### PR TITLE
Edit items [Closes #40]

### DIFF
--- a/models/item.js
+++ b/models/item.js
@@ -1,4 +1,7 @@
 'use strict';
+
+const VALID_PARAMETERS = [ 'completed', 'title', 'description' ]
+
 module.exports = function(sequelize, DataTypes) {
   var Item = sequelize.define('Item', {
     title: DataTypes.STRING,
@@ -10,6 +13,15 @@ module.exports = function(sequelize, DataTypes) {
     classMethods: {
       associate: function(models) {
         // associations can be defined here
+      },
+      filterParameters: params => {
+        return VALID_PARAMETERS.reduce( (memo, key) => {
+          if( params[ key ] !== undefined ) {
+            memo[ key ] = params[ key ]
+          }
+
+          return memo
+        }, {} )
       }
     }
   });

--- a/public/javascripts/items.js
+++ b/public/javascripts/items.js
@@ -1,4 +1,4 @@
-const fetchParams = {
+const FETCH_PARAMS = {
   method: 'post',
   headers: {
     'Accept': 'application/json',
@@ -7,28 +7,93 @@ const fetchParams = {
   credentials: 'include'
 }
 
-const params = completed =>
-  Object.assign( {}, fetchParams, { body: JSON.stringify({ completed }) })
+const RETURN_KEY = 13
+
+const params = data =>
+  Object.assign( {}, FETCH_PARAMS, { body: JSON.stringify( data ) } )
+
+const checkJsonForSuccessField = json => {
+  if( json.success ) {
+    Promise.resolve( json )
+  } else {
+    Promise.reject( json.message )
+  }
+}
+
+const selector = ( parent, id, tagToShow ) =>
+  `.${parent}[data-id=${id}] > ${tagToShow}`
+
+const toggle = ( elementToShow, elementToHide ) => {
+  $( elementToHide[ 0 ] ).addClass( 'hidden' )
+  $( elementToShow[ 0 ] ).removeClass( 'hidden' )
+}
+
+const clickToUpdate = parentClass => event => {
+  const elementToHide = $( event.target )
+  const id = elementToHide.data( 'id' )
+  const elementToShow = $( selector( parentClass, id, 'input' ) )
+
+  toggle( elementToShow, elementToHide )
+}
+
+const titleEdited = event => {
+  const elementToHide = $( event.target )
+  const id = elementToHide.data( 'id' )
+  const elementToShow = $( selector( 'title', id, 'span' ) )
+
+  if( event.charCode === RETURN_KEY ) {
+    let updatedTitle = elementToHide[0].value
+    fetch( `/items/${id}`, params( { title: updatedTitle } ) )
+      .then( result => result.json() )
+      .then ( checkJsonForSuccessField )
+      .then( json => {
+        toggle( elementToShow, elementToHide )
+        $( elementToShow[0] ).html(updatedTitle)
+    })
+  }
+}
+
+const descriptionEdited = event => {
+  const elementToHide = $( event.target )
+  const id = elementToHide.data( 'id' )
+  const elementToShow = $( selector( 'description', id, 'span' ) )
+
+  if( event.charCode === RETURN_KEY ) {
+    let updatedDescription = elementToHide[0].value
+    fetch( `/items/${id}`, params( { description: updatedDescription } ) )
+      .then( result => result.json() )
+      .then ( checkJsonForSuccessField )
+      .then( json => {
+        toggle( elementToShow, elementToHide )
+        $( elementToShow[0] ).html( updatedDescription )
+    })
+  }
+}
+
+const completedClicked = event => {
+  const element = $( event.target )
+  const id = element.data( 'id' )
+  const completed = ! element.data( 'completed' )
+
+  fetch( `/items/${id}`, params({ completed: completed } ) )
+    .then( result => result.json() )
+    .then( checkJsonForSuccessField )
+    .then( json => {
+      const parent = $( `.title[data-id=${id}]` )
+        element.data( 'completed', completed )
+        if( completed ) {
+          parent.addClass( 'completed' )
+        } else {
+          parent.removeClass( 'completed' )
+        }
+      }
+    )
+  }
 
 $(document).ready( () => {
-  $( '.title' ).click( event => {
-    const element = $( event.target )
-    const id = element.data( 'id' )
-    const completed = ! element.data( 'completed' )
-
-    fetch( `/items/${id}/completed`, params( completed ))
-      .then( result => result.json() )
-      .then( json => {
-        if( json.success ) {
-          element.data( 'completed', completed )
-
-          const parent = $( `.item[data-id=${id}]` )
-          if( completed ) {
-            parent.addClass( 'completed' )
-          } else {
-            parent.removeClass( 'completed' )
-          }
-        }
-      })
-  })
+  $( '.edit-title' ).keypress( titleEdited )
+  $( '.title > span' ).click( clickToUpdate( 'title' ))
+  $( '.edit-description' ).keypress( descriptionEdited )
+  $( '.description > span' ).click( clickToUpdate( 'description' ))
+  $( '.completeToggle' ).click( completedClicked )
 })

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -17,7 +17,19 @@
   padding-left: 7px;
 }
 
-.item.completed > .title {
+.title.completed > span, .title.completed > input {
   text-decoration: line-through;
   color: #777;
+}
+
+.heading > .title {
+  display: inline;
+}
+
+.heading {
+  display: inline;
+}
+
+.hidden {
+  display: none;
 }

--- a/routes/items.js
+++ b/routes/items.js
@@ -24,15 +24,16 @@ router.post( '/', ( request, response ) => {
     .then( result => response.redirect( '/items' ))
 })
 
-router.post( '/:id/completed', ( request, response ) => {
+router.post( '/:id', ( request, response ) => {
   const Item = request.app.get( 'models' ).Item
-
   const { id } = request.params
-  const { completed } = request.body
+  const where = { id, user_id: request.user.id }
 
-  Item.update({ completed }, { where: { id, user_id: request.user.id }})
+  Item.update( Item.filterParameters( request.body ), { where })
     .then( result => response.json({ success: true, id }))
-    .catch( error => response.json({ success: false, id, message: error.message }))
+    .catch( error =>
+      response.json({ success: false, id, message: error.message })
+    )
 })
 
 module.exports = router

--- a/views/items/index.pug
+++ b/views/items/index.pug
@@ -2,9 +2,15 @@ extends ../layouts/authenticated-layout
 
 mixin display( nodes, depth )
   each entry in nodes
-    .item(data-id=entry.id, class={completed: entry.completed})
-      .title(data-id=entry.id, data-completed=entry.completed)= entry.title
-      .description= entry.description
+    .item(data-id=entry.id)
+      .heading(data-id=entry.id, data-completed=entry.completed)
+        .completeToggle.glyphicon.glyphicon-ok(aria-hidden='true', data-id=entry.id, data-completed=entry.completed)
+        .title(data-id=entry.id, data-completed=entry.completed, class={completed: entry.completed})
+          span(data-id=entry.id)=entry.title
+          input.edit-title.hidden(data-id=entry.id, type='text', name='edit-title', value=entry.title)
+      .description(data-id=entry.id)
+          span(data-id=entry.id)=entry.description
+          input.edit-description.hidden(data-id=entry.id, type='text', name='edit-description', value=entry.description)
       .children
         +display( entry.children, depth + 1 )
 


### PR DESCRIPTION
- Shifted 'completed' toggle functionality to checkmark
- Wrote route for updating an item's title
- Wrote route for updating an item's description
- Restructured items display to allow for input
- Keypress 'enter' updates item's value, hides input, and makes span visible
- Click makes input visible and hides span